### PR TITLE
Enables Midround Flavor Text Editing

### DIFF
--- a/IS12Warfare.dme
+++ b/IS12Warfare.dme
@@ -1284,6 +1284,7 @@
 #include "code\modules\client\preference_setup\general\01_basic.dm"
 #include "code\modules\client\preference_setup\general\03_body.dm"
 #include "code\modules\client\preference_setup\general\04_equipment.dm"
+#include "code\modules\client\preference_setup\general\06_flavor.dm"
 #include "code\modules\client\preference_setup\global\01_ui.dm"
 #include "code\modules\client\preference_setup\global\02_prefixes.dm"
 #include "code\modules\client\preference_setup\global\03_pai.dm"

--- a/code/modules/client/preference_setup/general/06_flavor.dm
+++ b/code/modules/client/preference_setup/general/06_flavor.dm
@@ -2,10 +2,10 @@
 	var/list/flavor_texts        = list()
 	var/list/flavour_texts_robot = list()
 
-/*/datum/category_item/player_setup_item/general/flavor
+/datum/category_item/player_setup_item/general/flavor
 	name = "Flavor"
 	sort_order = 6
-*/
+
 /datum/category_item/player_setup_item/general/flavor/load_character(var/savefile/S)
 	S["flavor_texts_general"]	>> pref.flavor_texts["general"]
 	S["flavor_texts_head"]		>> pref.flavor_texts["head"]

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -427,7 +427,7 @@
 				return 0
 	else
 		return 0
-/*
+
 /mob/living/carbon/human/verb/pose()
 	set name = "Set Pose"
 	set desc = "Sets a description which will be shown when someone examines you."
@@ -476,4 +476,4 @@
 	HTML +="<a href='?src=\ref[src];flavor_change=done'>\[Done\]</a>"
 	HTML += "<tt>"
 	src << browse(jointext(HTML,null), "window=flavor_changes;size=430x300")
-*/
+


### PR DESCRIPTION
Makes it so you can set your Flavor Text midround

It says its enabled in Character Setup, but doesn't seem to work as your FT is empty when the round starts

Still looking into it