### PR TITLE
Disables LP and Water RNG

### DIFF
--- a/code/game/gamemodes/warfare/turfs.dm
+++ b/code/game/gamemodes/warfare/turfs.dm
@@ -10,7 +10,7 @@
 	atom_flags = ATOM_FLAG_CLIMBABLE
 	has_coldbreath = FALSE // No more freezing to death indoors.
 	var/has_light = TRUE
-	var/can_generate_water = TRUE
+	var/can_generate_water = FALSE
 	var/can_be_dug = TRUE
 
 /turf/simulated/floor/dirty/fake

--- a/code/game/objects/effects/lateparty.dm
+++ b/code/game/objects/effects/lateparty.dm
@@ -5,7 +5,7 @@
 	set name = "Late Party"
 	set desc= "Join a randomized late party picked from a list!"
 
-	var/partydelay = 48000 //in deciseconds (80 minutes)
+	var/partydelay = 432000 //in deciseconds (Twelve Hours, effectivly disabled. 48000 which is 80 Minutes was standard before.)
 
 	if(world.time < partydelay) //all this does is cause a delay so people can't suicide or observer and rush the base
 		to_chat(src, "It is too early for a late party! This will open when round duration reaches 0:40!")


### PR DESCRIPTION
Disables Lateparty Spawns by setting it to twelve hours and removes RNG water on the ground, one day I'll make our water not look like piss... one day